### PR TITLE
🔧 Update config to work with API v2.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ const options = {
   appSecret: 'APP_SECRET',
   callbackUrl: 'http://localhost:3000/auth/facebook/callback',
   path: '/auth/facebook',
-  fields: 'name,email,cover,first_name' // Check fields list here: https://developers.facebook.com/docs/graph-api/reference/v2.8/user
+	fields: 'name,email,cover,first_name', // Check fields list here: https://developers.facebook.com/docs/graph-api/reference/v2.11/user
+	scope: 'public_profile,email'	// Check permissions list here: https://developers.facebook.com/docs/facebook-login/permissions
 };
 
 const facebookAuth = microAuthFacebook(options);

--- a/example.js
+++ b/example.js
@@ -6,7 +6,8 @@ const options = {
   appSecret: 'APP_SECRET',
   callbackUrl: 'http://localhost:3000/auth/facebook/callback',
   path: '/auth/facebook',
-  fields: 'name,email,cover,first_name' // Check fields list here: https://developers.facebook.com/docs/graph-api/reference/v2.8/user
+	fields: 'name,email,cover,first_name', // Check fields list here: https://developers.facebook.com/docs/graph-api/reference/v2.11/user
+	scope: 'public_profile,email'	// Check permissions list here: https://developers.facebook.com/docs/facebook-login/permissions
 };
 
 const facebookAuth = microAuthFacebook(options);

--- a/index.js
+++ b/index.js
@@ -6,12 +6,11 @@ const redirect = require('micro-redirect');
 const uuid = require('uuid');
 
 const provider = 'facebook';
-const apiVersion = '2.8';
 
-const microAuthFacebook = ({ appId, appSecret, fields = 'name,email,cover', callbackUrl, path = '/auth/facebook' }) => {
+const microAuthFacebook = ({ appId, appSecret, fields = 'name,email,cover', callbackUrl, path = '/auth/facebook', scope = 'public_profile,email', apiVersion = '2.11' }) => {
 
   const getRedirectUrl = state => {
-    return `https://www.facebook.com/dialog/oauth?client_id=${appId}&redirect_uri=${callbackUrl}&response_type=code&state=${state}`;
+    return `https://www.facebook.com/dialog/oauth?client_id=${appId}&redirect_uri=${callbackUrl}&response_type=code&state=${state}&scope=${scope}`;
   };
 
   const getAccessTokenUrl = code => {


### PR DESCRIPTION
This PR updates the config to work with the latest Facebook API (v2.11) and future-proofs it by enabling user-specified API version. Also adds `scope`, which is now required in order to access `email`.